### PR TITLE
Add client_id and client_secret as token_options

### DIFF
--- a/lib/omniauth/strategies/nylas.rb
+++ b/lib/omniauth/strategies/nylas.rb
@@ -4,12 +4,14 @@ module OmniAuth
   module Strategies
     class Nylas < OmniAuth::Strategies::OAuth2
       option :name, "nylas"
-
       option :client_options, {
         :site          => "https://api.nylas.com",
         :authorize_url => "/oauth/authorize",
         :token_url     => "/oauth/token"
       }
+      option :client_id, ENV["NYLAS_APP_ID"]
+      option :client_secret, ENV["NYLAS_APP_SECRET"]
+      option :token_options, [:client_id, :client_secret]
 
       uid { access_token.params["account_id"] }
 


### PR DESCRIPTION
We add the client_id and the client_secret as token_options to accomplish nylas request